### PR TITLE
Use Latest Gorilla-REPL (0.4.1)

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,6 +6,6 @@
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [nstools "0.2.4"]
                  [anglican "1.0.0"]]
-  :plugins [[dtolpin/lein-gorilla "0.3.7-SNAPSHOT"]]
+  :plugins [[dtolpin/lein-gorilla "0.4.1-SNAPSHOT"]]
   :resource-paths ["programs"]
   :main ^:skip-aot anglican.core)


### PR DESCRIPTION
Updating to 0.4.1 enables MathJax formatting, and shows line numbers on cells while editing.